### PR TITLE
Added capybara gem + updated spec_helper to use it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,6 @@ gem "rest-client"
 
 # command line parsing for project registration
 gem "highline"
+
+# simplify rspec integration testing
+gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,12 @@ GEM
     atomic (1.1.14)
     bcrypt-ruby (3.1.2)
     builder (3.1.4)
+    capybara (2.1.0)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -60,8 +66,11 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.25)
+    mini_portile (0.5.2)
     minitest (4.7.5)
     multi_json (1.8.2)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
     orm_adapter (0.4.0)
     pg (0.17.0)
     polyglot (0.3.3)
@@ -149,11 +158,14 @@ GEM
       json (>= 1.8.0)
     warden (1.2.3)
       rack (>= 1.0)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   coffee-rails (~> 4.0.0)
   devise (~> 3.1)
   highline

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
+require 'capybara/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
**This pull requests adds the capybara gem, used to simplify integration testing, to the gemset of this project.
The `spec_helper.rb` file has been edited, so capybara will be included in all specs automatically.**

Note that this probably concerns all dev teams, as every team will have to write integration tests. Therefore i suggest this to be merged into the general develop branch.  
Capybara documentation can be found [here](http://rubydoc.info/github/jnicklas/capybara/master).

_Don't forget to do a `bundle install` after pulling this change._
