### PR TITLE
Revert "Bump tinymce-rails from 5.6.2.1 to 5.10.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ gem 'simple_form'
 gem 'traco'
 
 # WYSIWYG Text Editor
-gem 'tinymce-rails', '~> 5.10'
+gem 'tinymce-rails', '~> 5.6'
 gem 'tinymce-rails-langs', '~> 5.20200505'
 gem 'sanitize', '~> 5.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,7 +367,7 @@ GEM
     thor (1.1.0)
     tilt (2.0.10)
     timeliness (0.4.4)
-    tinymce-rails (5.10.2)
+    tinymce-rails (5.6.2.1)
       railties (>= 3.1.1)
     tinymce-rails-langs (5.20200505)
       tinymce-rails (~> 5.0)
@@ -461,7 +461,7 @@ DEPENDENCIES
   simple_form
   simplecov
   therubyracer (~> 0.12.0)
-  tinymce-rails (~> 5.10)
+  tinymce-rails (~> 5.6)
   tinymce-rails-langs (~> 5.20200505)
   traco
   uglifier


### PR DESCRIPTION
Reverts openHPI/hpi-connect-portal#834 because of issues with pasting job descriptions