### PR TITLE
Revert "Bump sdoc from 1.1.0 to 2.4.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'rubocop'
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
-  gem 'sdoc', '~> 2.4.0', require: false
+  gem 'sdoc', '~> 1.1.0', require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,8 +236,6 @@ GEM
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
-    psych (4.0.3)
-      stringio
     public_suffix (4.0.6)
     racc (1.6.0)
     rack (2.2.3)
@@ -280,8 +278,7 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.6)
-    rdoc (6.4.0)
-      psych (>= 4.0.0)
+    rdoc (6.3.1)
     ref (2.0.0)
     regexp_parser (2.1.1)
     rest-client (2.1.0)
@@ -336,7 +333,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sdoc (2.4.0)
+    sdoc (1.1.0)
       rdoc (>= 5.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -362,7 +359,6 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stringio (3.0.2)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
     therubyracer (0.12.3)
@@ -459,7 +455,7 @@ DEPENDENCIES
   safe_target_blank
   sanitize (~> 5.2)
   sassc-rails
-  sdoc (~> 2.4.0)
+  sdoc (~> 1.1.0)
   selenium-webdriver
   sentry-raven
   simple_form


### PR DESCRIPTION
Reverts openHPI/hpi-connect-portal#864

unfortunately we do not have controll over the servers JS instance, hence we still need to use this